### PR TITLE
Bump base and update repo link

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,0 +1,23 @@
+name: Build (Windows)
+on:
+  push:
+    branches: [ master, ci-* ]
+  pull_request:
+    branches: [ master, ci-* ]
+
+jobs:
+  build:
+    name: Build (GHC ${{ matrix.ghc }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - run: cabal build
+    - run: cabal haddock
+    - run: cabal check

--- a/windns.cabal
+++ b/windns.cabal
@@ -7,8 +7,8 @@ X-SPDX-License-Identifier: GPL-2.0-or-later
 license:             GPL-2
 license-files:       LICENSE LICENSE.GPLv2 LICENSE.GPLv3
 author:              Herbert Valerio Riedel
-maintainer:          hvr@gnu.org
-bug-reports:         https://github.com/hvr/windns/issues
+maintainer:          https://github.com/haskell-hvr/windns
+bug-reports:         https://github.com/haskell-hvr/windns/issues
 
 category:            Network
 build-type:          Simple
@@ -29,7 +29,7 @@ extra-source-files:  ChangeLog.md
 
 source-repository head
   type:              git
-  location:          https://github.com/hvr/windns.git
+  location:          https://github.com/haskell-hvr/windns.git
 
 flag allow-non-windows
   description:       Allow package to be built on @!os(windows)@
@@ -50,7 +50,7 @@ library
                      RecordWildCards
                      Trustworthy
 
-  build-depends:     base       >= 4.5.1.0 && < 4.16
+  build-depends:     base       >= 4.5.1.0 && < 5
                    , bytestring >= 0.9.2   && < 0.12
                    , deepseq    >= 1.3.0.0 && < 1.5
 


### PR DESCRIPTION
Add CI on Github for Windows GHCs 8.0 - 9.6.

Given the [revision history](https://hackage.haskell.org/package/windns-0.1.0.1/revisions/) of this package, I think a big bound bump to `base < 5` will give better net value for the Haskell Ecosystem.

Closes #3. Closes #5.